### PR TITLE
Fix meta tag quotes and duplicate head

### DIFF
--- a/DiLei.html
+++ b/DiLei.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
 <html lang="jp">
-<head>
+<head prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb# article: http://ogp.me/ns/article#">
 <meta charset="utf-8">
 <title> 『七爺』地雷数</title>
 <meta name="description" content="『七爺』原作有料公開部分の日本語訳をお読み頂くにあたって必要な地雷投下数">
 <meta name="robots" content="noindex">
-<head prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb# article: http://ogp.me/ns/article#">
 <meta property="og:title" content="『七爺』地雷数" />
 <meta property="og:url" content="https://anlan0613.github.io/QiYe/confirmation.html" />
 <meta property="og:image" content="https://anlan0613.github.io/QiYe/IconC.png" />
@@ -14,9 +13,9 @@
 <meta property="og:site_name" content="anlan0613" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@anlan_wayaku" />
-<meta name=”twitter:title” content=” 『七爺』地雷数”>
-<meta name=”twitter:description” content=”『七爺』原作有料公開部分の日本語訳をお読み頂くにあたって必要な地雷投下数”>
-<meta name=”twitter:image” content=”https://anlan0613.github.io/QiYe/IconC.png”>
+<meta name="twitter:title" content=" 『七爺』地雷数">
+<meta name="twitter:description" content="『七爺』原作有料公開部分の日本語訳をお読み頂くにあたって必要な地雷投下数">
+<meta name="twitter:image" content="https://anlan0613.github.io/QiYe/IconC.png">
 <meta name="viewport" content="width=device-width,minimum-scale=1.0,maximum-scale=1.0,user-scalable=no">
 <link rel="stylesheet" href="stylesheet.css">
 </head>

--- a/chapter01.html
+++ b/chapter01.html
@@ -23,7 +23,7 @@
     <meta name="twitter:title" content="『七爺』第一章" />
     <meta name="twitter:description" content="第一章：七世の浮生" />
     <meta name="twitter:image"
-    content=”https://anlan0613.github.io/QiYe/IconF.png”>
+    content="https://anlan0613.github.io/QiYe/IconF.png">
     <meta
       name="viewport"
       content="width=device-width,minimum-scale=1.0,maximum-scale=1.0,user-scalable=no"

--- a/chapter02.html
+++ b/chapter02.html
@@ -22,8 +22,8 @@
     <meta name="twitter:site" content="@anlan_wayaku" />
     <meta name="twitter:title" content="『七爺』第二章" />
     <meta name="twitter:description" content="第二章：帰り去るに如かず" />
-    <meta name=”twitter:image”
-    content=”https://anlan0613.github.io/QiYe/IconF.png”>
+    <meta name="twitter:image"
+    content="https://anlan0613.github.io/QiYe/IconF.png">
     <meta
       name="viewport"
       content="width=device-width,minimum-scale=1.0,maximum-scale=1.0,user-scalable=no"

--- a/chapter03.html
+++ b/chapter03.html
@@ -22,8 +22,8 @@
     <meta name="twitter:site" content="@anlan_wayaku" />
     <meta name="twitter:title" content="『七爺』第三章" />
     <meta name="twitter:description" content="第三章：故人猶ほ在るがごとし" />
-    <meta name=”twitter:image”
-    content=”https://anlan0613.github.io/QiYe/IconF.png”>
+    <meta name="twitter:image"
+    content="https://anlan0613.github.io/QiYe/IconF.png">
     <meta
       name="viewport"
       content="width=device-width,minimum-scale=1.0,maximum-scale=1.0,user-scalable=no"

--- a/chapter04.html
+++ b/chapter04.html
@@ -22,8 +22,8 @@
     <meta name="twitter:site" content="@anlan_wayaku" />
     <meta name="twitter:title" content="『七爺』第四章" />
     <meta name="twitter:description" content="第四章：浮世の栄華" />
-    <meta name=”twitter:image”
-    content=”https://anlan0613.github.io/QiYe/IconF.png”>
+    <meta name="twitter:image"
+    content="https://anlan0613.github.io/QiYe/IconF.png">
     <meta
       name="viewport"
       content="width=device-width,minimum-scale=1.0,maximum-scale=1.0,user-scalable=no"

--- a/chapter05.html
+++ b/chapter05.html
@@ -22,8 +22,8 @@
     <meta name="twitter:site" content="@anlan_wayaku" />
     <meta name="twitter:title" content="『七爺』第五章" />
     <meta name="twitter:description" content="第五章：適当なあしらい" />
-    <meta name=”twitter:image”
-    content=”https://anlan0613.github.io/QiYe/IconF.png”>
+    <meta name="twitter:image"
+    content="https://anlan0613.github.io/QiYe/IconF.png">
     <meta
       name="viewport"
       content="width=device-width,minimum-scale=1.0,maximum-scale=1.0,user-scalable=no"

--- a/chapter28.html
+++ b/chapter28.html
@@ -1,10 +1,9 @@
 <!DOCTYPE html>
 <html lang="jp">
-<head>
+<head prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb# article: http://ogp.me/ns/article#">
 <meta charset="utf-8">
 <title>『七爺』第二十八章 </title>
 <meta name="description" content="第二十八章：タイトル">
-<head prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb# article: http://ogp.me/ns/article#">
 <meta property="og:title" content="『七爺』第二十八章" />
 <meta property="og:url" content="https://anlan0613.github.io/QiYe/chapter28.html" />
 <meta property="og:image" content="https://anlan0613.github.io/QiYe/IconV.png" />
@@ -13,9 +12,9 @@
 <meta property="og:site_name" content="anlan0613" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@anlan_wayaku" />
-<meta name=”twitter:title” content=”『七爺』第二十八章”>
-<meta name=”twitter:description” content=”第二十八章：タイトル”>
-<meta name=”twitter:image” content=”https://anlan0613.github.io/QiYe/IconV.png”>
+<meta name="twitter:title" content="『七爺』第二十八章">
+<meta name="twitter:description" content="第二十八章：タイトル">
+<meta name="twitter:image" content="https://anlan0613.github.io/QiYe/IconV.png">
 <meta name="viewport" content="width=device-width,minimum-scale=1.0,maximum-scale=1.0,user-scalable=no">
 <meta http-equiv="refresh" content="3;URL=https://tinyurl.com/4sdwchyd">
 <link rel="stylesheet" href="stylesheet.css">

--- a/confirmation.html
+++ b/confirmation.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
 <html lang="jp">
-<head>
+<head prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb# article: http://ogp.me/ns/article#">
 <meta charset="utf-8">
 <title> 『七爺』原作有料公開部分について </title>
 <meta name="description" content="『七爺』原作有料公開部分の日本語訳をお読み頂くにあたってのお願い">
 <meta name="robots" content="noindex">
-<head prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb# article: http://ogp.me/ns/article#">
 <meta property="og:title" content="『七爺』原作有料公開部分について" />
 <meta property="og:url" content="https://anlan0613.github.io/QiYe/confirmation.html" />
 <meta property="og:image" content="https://anlan0613.github.io/QiYe/IconC.png" />
@@ -14,9 +13,9 @@
 <meta property="og:site_name" content="anlan0613" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@anlan_wayaku" />
-<meta name=”twitter:title” content=” 『七爺』原作有料公開部分について”>
-<meta name=”twitter:description” content=”『七爺』原作有料公開部分の日本語訳をお読み頂くにあたってのお願い”>
-<meta name=”twitter:image” content=”https://anlan0613.github.io/QiYe/IconC.png”>
+<meta name="twitter:title" content=" 『七爺』原作有料公開部分について">
+<meta name="twitter:description" content="『七爺』原作有料公開部分の日本語訳をお読み頂くにあたってのお願い">
+<meta name="twitter:image" content="https://anlan0613.github.io/QiYe/IconC.png">
 <meta name="viewport" content="width=device-width,minimum-scale=1.0,maximum-scale=1.0,user-scalable=no">
 <link rel="stylesheet" href="stylesheet.css">
 </head>

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
       content="priest原作小説『七爺（七爷）』のファンによる和訳/日本語訳です。ドラマ『山河令』原作小説『天涯客』の姉妹作（前作）。"
     />
     <meta name="twitter:image"
-    content=”https://anlan0613.github.io/QiYe/img/QiyeDawu.jpeg”>
+    content="https://anlan0613.github.io/QiYe/img/QiyeDawu.jpeg">
     <meta
       name="viewport"
       content="width=device-width,minimum-scale=1.0,maximum-scale=1.0,user-scalable=no"

--- a/refresh-test.html
+++ b/refresh-test.html
@@ -1,13 +1,12 @@
 <!DOCTYPE html>
 <html lang="jp">
-<head>
+<head prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb# article: http://ogp.me/ns/article#">
 <meta charset="utf-8">
 <title>『七爺』test </title>
 <meta name="description" content="第test章：タイトル">
 
 <meta name="robots" content="noindex">
 
-<head prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb# article: http://ogp.me/ns/article#">
 <meta property="og:title" content="『七爺』第test章" />
 <meta property="og:url" content="https://anlan0613.github.io/QiYe/refresh-test.html" />
 <meta property="og:image" content="https://anlan0613.github.io/QiYe/IconV.png" />
@@ -16,9 +15,9 @@
 <meta property="og:site_name" content="anlan0613" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@anlan_wayaku" />
-<meta name=”twitter:title” content=”『七爺』第test章”>
-<meta name=”twitter:description” content=”第test章：タイトル”>
-<meta name=”twitter:image” content=”https://anlan0613.github.io/QiYe/IconV.png”>
+<meta name="twitter:title" content="『七爺』第test章">
+<meta name="twitter:description" content="第test章：タイトル">
+<meta name="twitter:image" content="https://anlan0613.github.io/QiYe/IconV.png">
 <meta http-equiv="refresh" content="2; URL= https://tinyurl.com/a5w6y4se">
 <meta name="viewport" content="width=device-width,minimum-scale=1.0,maximum-scale=1.0,user-scalable=no">
 <link rel="stylesheet" href="stylesheet.css">


### PR DESCRIPTION
## Summary
- correct `<head>` tags in several HTML files
- replace curly quotes in meta attributes with standard quotes for valid markup

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683fc6d8ab048320ad59cbe0c923913a